### PR TITLE
fix: Build CLI before running tests in all workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Build
+        run: npm run build
+
       - name: Run tests
         run: npm test
-
-      - name: Verify build
-        run: npm run build
 
   build-and-release:
     needs: validate
@@ -57,11 +57,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm test
-
       - name: Build
         run: npm run build
+
+      - name: Run tests
+        run: npm test
 
       - name: Create release archive
         shell: bash


### PR DESCRIPTION
## Problem

E2E tests were failing in CI workflows because tests were running before the CLI was built. The E2E tests require `dist/cli.js` to exist when they spawn the CLI binary.

## Solution

Updated all workflows to build before running tests:

1. **`.github/workflows/release.yml`**:
   - `validate` job: Moved Build step before Run tests (removed redundant "Verify build" step)
   - `build-and-release` job: Moved Build step before Run tests

2. **`.github/workflows/release-please.yml`**:
   - `test` job: Added Build step before Run tests

3. **`.github/workflows/test.yml`**:
   - Already correct (Build before tests)

## Changes

All workflows now follow the correct order:
1. Install dependencies
2. Run linter (where applicable)
3. **Build** (creates `dist/cli.js`)
4. **Run tests** (E2E tests can now find the CLI binary)

## Testing

- All 715 tests passing locally
- E2E tests now have access to built CLI binary in all workflows
- Consistent build order across all CI workflows