### PR TITLE
feat: add configurable scoring weights for task prioritization

### DIFF
--- a/plans/0030-limps-scoring-weights/agents/000_phase1_core-weights.agent.md
+++ b/plans/0030-limps-scoring-weights/agents/000_phase1_core-weights.agent.md
@@ -1,0 +1,117 @@
+---
+title: Core Weight System
+status: PASS
+persona: coder
+dependencies: []
+blocks: ["001", "002", "003", "004"]
+tags: [limps/agent, limps/status/pass, limps/persona/coder]
+aliases: ["#000", "Core Weights Agent"]
+created: 2026-01-27
+updated: 2026-01-27
+files:
+  - path: src/config.ts
+    action: modify
+  - path: src/cli/next-task.ts
+    action: modify
+  - path: tests/cli/next-task.test.ts
+    action: modify
+---
+
+# Agent 000: Core Weight System
+
+**Plan Location**: `plans/0030-limps-scoring-weights/plan.md`
+
+## Scope
+
+Features: Phase 1 - Core Weight System
+Own: ScoringWeights interface, weight configuration, scoring functions
+Depend on: Nothing
+Block: All other agents
+
+## Critical Context
+
+This is the foundation. All other phases build on this.
+
+## Interfaces
+
+### Export (from config.ts)
+
+```typescript
+export interface ScoringWeights {
+  dependency: number;  // default: 40
+  priority: number;    // default: 30
+  workload: number;    // default: 30
+}
+
+export interface ServerConfig {
+  // ... existing fields
+  scoring?: {
+    weights?: Partial<ScoringWeights>;
+  };
+}
+
+export const DEFAULT_SCORING_WEIGHTS: ScoringWeights;
+export function getScoringWeights(config: ServerConfig): ScoringWeights;
+```
+
+### Updated (next-task.ts)
+
+```typescript
+function calculateDependencyScore(agent, allAgents, maxScore = 40);
+function calculatePriorityScore(agent, maxScore = 30);
+function calculateWorkloadScore(agent, maxScore = 30);
+function scoreTask(agent, allAgents, weights?: ScoringWeights);
+```
+
+---
+
+## Features
+
+### #0: ScoringWeights Interface
+
+TL;DR: Define the interface for configurable weights
+Status: `PASS`
+
+Implementation:
+- Added `ScoringWeights` interface with dependency/priority/workload
+- Extended `ServerConfig` with optional `scoring.weights`
+- Created `DEFAULT_SCORING_WEIGHTS` constant (40/30/30)
+- Created `getScoringWeights()` helper
+
+### #1: Parameterized Scoring Functions
+
+TL;DR: Update scoring functions to accept configurable max scores
+Status: `PASS`
+
+Implementation:
+- `calculateDependencyScore()` accepts optional `maxScore` parameter
+- `calculatePriorityScore()` accepts optional `maxScore` parameter
+- `calculateWorkloadScore()` accepts optional `maxScore` parameter
+- `scoreTask()` accepts optional `ScoringWeights` and passes to functions
+- `getNextTaskData()` loads weights from config
+
+### #2: Output Formatting
+
+TL;DR: Display dynamic max scores in CLI output
+Status: `PASS`
+
+Implementation:
+- `nextTask()` displays actual weights in score breakdown
+- Total score shows sum of configured weights
+
+---
+
+## Done
+
+- [x] ScoringWeights interface added to config.ts
+- [x] DEFAULT_SCORING_WEIGHTS constant defined
+- [x] getScoringWeights() helper function
+- [x] calculateDependencyScore() accepts maxScore
+- [x] calculatePriorityScore() accepts maxScore
+- [x] calculateWorkloadScore() accepts maxScore
+- [x] scoreTask() accepts weights parameter
+- [x] getNextTaskData() loads weights from config
+- [x] CLI output shows dynamic max scores
+- [x] Tests for default weights
+- [x] Tests for custom weights
+- [x] Tests for partial overrides

--- a/plans/0030-limps-scoring-weights/agents/001_phase2_biases.agent.md
+++ b/plans/0030-limps-scoring-weights/agents/001_phase2_biases.agent.md
@@ -1,0 +1,124 @@
+---
+title: Scoring Biases
+status: GAP
+persona: coder
+dependencies: ["000"]
+blocks: ["003", "004"]
+tags: [limps/agent, limps/status/gap, limps/persona/coder]
+aliases: ["#001", "Biases Agent"]
+created: 2026-01-27
+updated: 2026-01-27
+files:
+  - path: src/config.ts
+    action: modify
+  - path: src/cli/next-task.ts
+    action: modify
+  - path: tests/cli/next-task.test.ts
+    action: modify
+---
+
+# Agent 001: Scoring Biases
+
+**Plan Location**: `plans/0030-limps-scoring-weights/plan.md`
+
+## Scope
+
+Features: Phase 2 - Biases
+Own: ScoringBiases interface, bias application logic
+Depend on: Agent 000 (Core Weight System)
+Block: Agents 003, 004
+
+## Critical Context
+
+Biases add/subtract from the weighted score. They allow prioritizing specific plans, personas, or statuses.
+
+## Interfaces
+
+### Export (from config.ts)
+
+```typescript
+export interface ScoringBiases {
+  plans?: {
+    [planId: string]: number;  // -50 to +50 bias
+  };
+  personas?: {
+    coder?: number;
+    reviewer?: number;
+    pm?: number;
+    customer?: number;
+  };
+  statuses?: {
+    GAP?: number;
+    WIP?: number;
+    BLOCKED?: number;
+  };
+}
+
+export interface ServerConfig {
+  scoring?: {
+    weights?: Partial<ScoringWeights>;
+    biases?: Partial<ScoringBiases>;
+  };
+}
+
+export const DEFAULT_SCORING_BIASES: ScoringBiases;
+export function getScoringBiases(config: ServerConfig): ScoringBiases;
+```
+
+---
+
+## Features
+
+### #0: ScoringBiases Interface
+
+TL;DR: Define the interface for configurable biases
+Status: `GAP`
+
+TDD:
+1. `ScoringBiases interface exists` → add to config.ts → export
+2. `DEFAULT_SCORING_BIASES = {}` → all biases default to 0
+3. `getScoringBiases() merges with defaults` → test partial overrides
+
+### #1: Plan Biases
+
+TL;DR: Allow +/- score adjustment per plan
+Status: `GAP`
+
+TDD:
+1. `plan bias applied to score` → match planFolder → add bias
+2. `unknown plan = no bias` → no crash, just skip
+3. `bias can be negative` → subtract from score
+
+### #2: Persona Biases
+
+TL;DR: Allow +/- score adjustment per persona
+Status: `GAP`
+
+TDD:
+1. `persona bias applied to score` → match agent.frontmatter.persona → add bias
+2. `unknown persona = no bias` → no crash
+3. `config example: reviewer: -10` → reviewer tasks deprioritized
+
+### #3: Status Biases
+
+TL;DR: Allow +/- score adjustment per status
+Status: `GAP`
+
+TDD:
+1. `status bias applied to score` → only GAP tasks scored, but still useful
+2. `BLOCKED bias for visibility` → surface blocked tasks if desired
+
+---
+
+## Done
+
+- [ ] ScoringBiases interface added to config.ts
+- [ ] DEFAULT_SCORING_BIASES constant defined
+- [ ] getScoringBiases() helper function
+- [ ] Plan biases applied in scoreTask()
+- [ ] Persona biases applied in scoreTask()
+- [ ] Status biases applied in scoreTask()
+- [ ] Score floored at 0 (no negative scores)
+- [ ] Tests for plan biases
+- [ ] Tests for persona biases
+- [ ] Tests for combined biases

--- a/plans/0030-limps-scoring-weights/agents/002_phase3_presets-cli.agent.md
+++ b/plans/0030-limps-scoring-weights/agents/002_phase3_presets-cli.agent.md
@@ -1,0 +1,135 @@
+---
+title: Presets & CLI
+status: GAP
+persona: coder
+dependencies: ["000", "001"]
+blocks: ["004"]
+tags: [limps/agent, limps/status/gap, limps/persona/coder]
+aliases: ["#002", "Presets CLI Agent"]
+created: 2026-01-27
+updated: 2026-01-27
+files:
+  - path: src/config.ts
+    action: modify
+  - path: src/cli/next-task.ts
+    action: modify
+  - path: src/commands/config.tsx
+    action: modify
+  - path: tests/cli/next-task.test.ts
+    action: modify
+  - path: tests/commands/config.test.tsx
+    action: modify
+---
+
+# Agent 002: Presets & CLI
+
+**Plan Location**: `plans/0030-limps-scoring-weights/plan.md`
+
+## Scope
+
+Features: Phase 3 - Presets & CLI
+Own: Preset definitions, CLI scoring commands
+Depend on: Agents 000, 001
+Block: Agent 004
+
+## Critical Context
+
+Presets are named configurations for common use cases. CLI commands let users inspect and modify scoring.
+
+## Interfaces
+
+### Presets (from config.ts)
+
+```typescript
+export type ScoringPreset = 'default' | 'quick-wins' | 'dependency-chain' | 'newest-first' | 'code-then-review';
+
+export const SCORING_PRESETS: Record<ScoringPreset, { weights: ScoringWeights; biases: ScoringBiases }> = {
+  'default': { weights: { dependency: 40, priority: 30, workload: 30 }, biases: {} },
+  'quick-wins': { weights: { dependency: 20, priority: 20, workload: 60 }, biases: {} },
+  'dependency-chain': { weights: { dependency: 60, priority: 20, workload: 20 }, biases: { statuses: { BLOCKED: 20 } } },
+  'newest-first': { weights: { dependency: 30, priority: 30, workload: 20, recency: 20 }, biases: {} },
+  'code-then-review': { weights: { dependency: 40, priority: 30, workload: 30 }, biases: { personas: { coder: 10, reviewer: -10 } } }
+};
+
+export interface ServerConfig {
+  scoring?: {
+    preset?: ScoringPreset;
+    weights?: Partial<ScoringWeights>;
+    biases?: Partial<ScoringBiases>;
+  };
+}
+```
+
+---
+
+## Features
+
+### #0: Preset Definitions
+
+TL;DR: Define named presets for common configurations
+Status: `GAP`
+
+TDD:
+1. `SCORING_PRESETS constant exists` → define all 5 presets
+2. `preset applied when set` → override defaults with preset values
+3. `custom weights override preset` → layered: defaults < preset < custom
+
+### #1: CLI Scoring Config
+
+TL;DR: Commands to view and modify scoring config
+Status: `GAP`
+
+Commands:
+```bash
+limps config scoring              # View current scoring config
+limps config scoring --preset X   # Set a preset
+limps config scoring --weight X=Y # Adjust individual weight
+limps config scoring --bias X=Y   # Add bias
+```
+
+TDD:
+1. `config scoring shows weights` → display current config
+2. `--preset sets preset in config` → write to config.json
+3. `--weight updates individual` → merge with existing
+
+### #2: Score Task Command
+
+TL;DR: Command to see how a specific task scores
+Status: `GAP`
+
+```bash
+limps score-task 0027#001
+```
+
+TDD:
+1. `shows full breakdown` → weights, biases, total
+2. `handles invalid task` → error message
+
+### #3: Score All Command
+
+TL;DR: Compare scoring across all tasks in a plan
+Status: `GAP`
+
+```bash
+limps score-all --plan 0027
+```
+
+TDD:
+1. `lists all tasks with scores` → sorted by score desc
+2. `shows which would be next` → mark the winner
+
+---
+
+## Done
+
+- [ ] SCORING_PRESETS constant defined
+- [ ] Preset selection in config.json
+- [ ] Preset applied before custom weights/biases
+- [ ] `limps config scoring` shows config
+- [ ] `--preset` flag sets preset
+- [ ] `--weight` flag adjusts weights
+- [ ] `--bias` flag adds biases
+- [ ] `limps score-task` command
+- [ ] `limps score-all` command
+- [ ] Tests for presets
+- [ ] Tests for CLI commands

--- a/plans/0030-limps-scoring-weights/agents/003_phase4_overrides.agent.md
+++ b/plans/0030-limps-scoring-weights/agents/003_phase4_overrides.agent.md
@@ -1,0 +1,115 @@
+---
+title: Granular Overrides
+status: GAP
+persona: coder
+dependencies: ["000", "001"]
+blocks: ["004"]
+tags: [limps/agent, limps/status/gap, limps/persona/coder]
+aliases: ["#003", "Overrides Agent"]
+created: 2026-01-27
+updated: 2026-01-27
+files:
+  - path: src/agent-parser.ts
+    action: modify
+  - path: src/cli/next-task.ts
+    action: modify
+  - path: tests/cli/next-task.test.ts
+    action: modify
+---
+
+# Agent 003: Granular Overrides
+
+**Plan Location**: `plans/0030-limps-scoring-weights/plan.md`
+
+## Scope
+
+Features: Phase 4 - Granular Overrides
+Own: Plan-level and agent-level scoring overrides
+Depend on: Agents 000, 001
+Block: Agent 004
+
+## Critical Context
+
+Allow scoring to be overridden at plan or agent level via frontmatter. More specific overrides win.
+
+## Interfaces
+
+### Plan Frontmatter
+
+```yaml
+---
+title: Urgent Bugfix
+scoring:
+  bias: 30           # This plan gets +30 to all tasks
+  weights:           # Override global weights for this plan
+    dependency: 60
+    workload: 20
+    priority: 20
+---
+```
+
+### Agent Frontmatter
+
+```yaml
+---
+status: GAP
+persona: coder
+scoring:
+  bias: 10           # This specific task gets +10
+---
+```
+
+---
+
+## Features
+
+### #0: Plan Frontmatter Scoring
+
+TL;DR: Parse scoring section from plan.md frontmatter
+Status: `GAP`
+
+TDD:
+1. `plan frontmatter parsed` → extract scoring.bias and scoring.weights
+2. `plan weights override global` → merge with global config
+3. `plan bias applied` → add to all tasks in plan
+
+### #1: Agent Frontmatter Scoring
+
+TL;DR: Parse scoring section from agent frontmatter
+Status: `GAP`
+
+TDD:
+1. `agent frontmatter parsed` → extend AgentFrontmatter type
+2. `agent bias applied` → add to individual task score
+3. `agent bias stacks with plan` → plan bias + agent bias
+
+### #2: Override Precedence
+
+TL;DR: More specific overrides win
+Status: `GAP`
+
+Precedence (later wins):
+1. Global config (config.json)
+2. Preset (if set)
+3. Plan frontmatter
+4. Agent frontmatter
+
+TDD:
+1. `agent weight overrides plan` → verify agent wins
+2. `plan weight overrides global` → verify plan wins
+3. `missing override uses parent` → fallback chain works
+
+---
+
+## Done
+
+- [ ] Plan frontmatter scoring section parsed
+- [ ] Plan-level weights override global
+- [ ] Plan-level bias applied to all tasks
+- [ ] Agent frontmatter scoring section parsed
+- [ ] Agent-level bias applied
+- [ ] Override precedence documented and tested
+- [ ] AgentFrontmatter type extended
+- [ ] Tests for plan overrides
+- [ ] Tests for agent overrides
+- [ ] Tests for precedence

--- a/plans/0030-limps-scoring-weights/agents/004_phase5_mcp.agent.md
+++ b/plans/0030-limps-scoring-weights/agents/004_phase5_mcp.agent.md
@@ -1,0 +1,126 @@
+---
+title: MCP Integration
+status: GAP
+persona: coder
+dependencies: ["000", "001", "002", "003"]
+blocks: []
+tags: [limps/agent, limps/status/gap, limps/persona/coder]
+aliases: ["#004", "MCP Agent"]
+created: 2026-01-27
+updated: 2026-01-27
+files:
+  - path: src/tools/index.ts
+    action: modify
+  - path: src/tools/get-next-task.ts
+    action: modify
+  - path: tests/get-next-task.test.ts
+    action: modify
+---
+
+# Agent 004: MCP Integration
+
+**Plan Location**: `plans/0030-limps-scoring-weights/plan.md`
+
+## Scope
+
+Features: Phase 5 - MCP Integration
+Own: MCP tool updates, configure_scoring tool
+Depend on: All previous agents
+Block: Nothing (final phase)
+
+## Critical Context
+
+Update the MCP `get_next_task` tool response and add a new `configure_scoring` tool.
+
+## Interfaces
+
+### Updated get_next_task Response
+
+```typescript
+{
+  taskId: "0027-limps-roadmap#002",
+  title: "Implement scoring weights",
+  totalScore: 95,
+  breakdown: {
+    dependency: { raw: 1.0, weighted: 40, weight: 40 },
+    priority: { raw: 0.8, weighted: 24, weight: 30 },
+    workload: { raw: 0.7, weighted: 21, weight: 30 },
+    biases: {
+      plan: 5,
+      persona: 0,
+      agent: 5
+    }
+  },
+  configUsed: "quick-wins",  // or "custom" or "default"
+  otherAvailableTasks: 5
+}
+```
+
+### New Tool: configure_scoring
+
+```typescript
+tool: "configure_scoring"
+params: {
+  weights?: Partial<ScoringWeights>;
+  biases?: Partial<ScoringBiases>;
+  preset?: ScoringPreset;
+  scope?: "global" | "plan" | "agent";
+  targetId?: string;  // Plan or agent ID if scoped
+}
+```
+
+---
+
+## Features
+
+### #0: Enhanced get_next_task Response
+
+TL;DR: Return detailed score breakdown in MCP response
+Status: `GAP`
+
+TDD:
+1. `response includes breakdown` → raw, weighted, weight for each factor
+2. `response includes biases` → plan, persona, agent biases shown
+3. `response includes configUsed` → identify which config/preset active
+4. `backward compatible` → existing fields unchanged
+
+### #1: configure_scoring Tool
+
+TL;DR: MCP tool to modify scoring config
+Status: `GAP`
+
+TDD:
+1. `set preset via tool` → update config.json
+2. `adjust weight via tool` → merge with existing
+3. `scope to plan/agent` → write to frontmatter
+4. `validation errors` → invalid preset, out of range values
+
+### #2: Validation & Error Handling
+
+TL;DR: Robust validation for all scoring inputs
+Status: `GAP`
+
+TDD:
+1. `weights must be non-negative` → error if < 0
+2. `biases in range -50 to +50` → warn if extreme
+3. `unknown preset returns error` → list valid presets
+4. `scope requires targetId` → error if missing
+
+---
+
+## Done
+
+- [ ] get_next_task returns score breakdown
+- [ ] Breakdown includes raw, weighted, weight
+- [ ] Breakdown includes all bias sources
+- [ ] configUsed field shows active preset/custom
+- [ ] configure_scoring tool registered
+- [ ] Tool updates global config
+- [ ] Tool supports plan scope
+- [ ] Tool supports agent scope
+- [ ] Validation for weights
+- [ ] Validation for biases
+- [ ] Validation for presets
+- [ ] Tests for enhanced response
+- [ ] Tests for configure_scoring
+- [ ] Tests for validation

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,15 @@ import { resolve, dirname } from 'path';
 import { homedir } from 'os';
 
 /**
+ * Scoring weights for task prioritization.
+ */
+export interface ScoringWeights {
+  dependency: number; // default: 40
+  priority: number; // default: 30
+  workload: number; // default: 30
+}
+
+/**
  * Server configuration interface.
  */
 export interface ServerConfig {
@@ -10,12 +19,37 @@ export interface ServerConfig {
   docsPaths?: string[]; // Additional paths to index
   fileExtensions?: string[]; // File types to index (default: ['.md'])
   dataPath: string;
+  scoring?: {
+    weights?: Partial<ScoringWeights>;
+  };
 }
 
 /**
  * Default file extensions to index.
  */
 const DEFAULT_FILE_EXTENSIONS = ['.md'];
+
+/**
+ * Default scoring weights for task prioritization.
+ */
+export const DEFAULT_SCORING_WEIGHTS: ScoringWeights = {
+  dependency: 40,
+  priority: 30,
+  workload: 30,
+};
+
+/**
+ * Get scoring weights from config, merging with defaults.
+ *
+ * @param config - Server configuration
+ * @returns Complete scoring weights with defaults applied
+ */
+export function getScoringWeights(config: ServerConfig): ScoringWeights {
+  return {
+    ...DEFAULT_SCORING_WEIGHTS,
+    ...config.scoring?.weights,
+  };
+}
 
 /**
  * Default debounce delay for file watching (ms).

--- a/tests/cli/next-task.test.ts
+++ b/tests/cli/next-task.test.ts
@@ -11,6 +11,7 @@ import {
   scoreTask,
 } from '../../src/cli/next-task.js';
 import type { ServerConfig } from '../../src/config.js';
+import { DEFAULT_SCORING_WEIGHTS, getScoringWeights } from '../../src/config.js';
 import type { ParsedAgentFile, AgentFrontmatter } from '../../src/agent-parser.js';
 
 describe('next-task', () => {
@@ -384,6 +385,193 @@ files: []
     it('handles plan not found', async () => {
       const result = await nextTask(config, '99');
       expect(result).toContain('Plan not found: 99');
+    });
+  });
+
+  describe('configurable weights', () => {
+    describe('getScoringWeights', () => {
+      it('returns defaults when no scoring config', () => {
+        const weights = getScoringWeights(config);
+
+        expect(weights).toEqual(DEFAULT_SCORING_WEIGHTS);
+        expect(weights.dependency).toBe(40);
+        expect(weights.priority).toBe(30);
+        expect(weights.workload).toBe(30);
+      });
+
+      it('applies custom weights from config', () => {
+        const customConfig: ServerConfig = {
+          ...config,
+          scoring: {
+            weights: {
+              dependency: 50,
+              priority: 25,
+              workload: 25,
+            },
+          },
+        };
+
+        const weights = getScoringWeights(customConfig);
+
+        expect(weights.dependency).toBe(50);
+        expect(weights.priority).toBe(25);
+        expect(weights.workload).toBe(25);
+      });
+
+      it('allows partial weight overrides', () => {
+        const customConfig: ServerConfig = {
+          ...config,
+          scoring: {
+            weights: {
+              dependency: 60,
+            },
+          },
+        };
+
+        const weights = getScoringWeights(customConfig);
+
+        expect(weights.dependency).toBe(60);
+        expect(weights.priority).toBe(30); // default
+        expect(weights.workload).toBe(30); // default
+      });
+
+      it('handles empty scoring object', () => {
+        const customConfig: ServerConfig = {
+          ...config,
+          scoring: {},
+        };
+
+        const weights = getScoringWeights(customConfig);
+
+        expect(weights).toEqual(DEFAULT_SCORING_WEIGHTS);
+      });
+    });
+
+    describe('calculateDependencyScore with custom maxScore', () => {
+      it('uses custom maxScore when provided', () => {
+        const agent = createMockAgent();
+        const allAgents = [agent];
+
+        const result = calculateDependencyScore(agent, allAgents, 50);
+
+        expect(result.score).toBe(50);
+      });
+
+      it('returns custom maxScore when all dependencies satisfied', () => {
+        const agent = createMockAgent({
+          frontmatter: {
+            status: 'GAP',
+            persona: 'coder',
+            dependencies: ['001'],
+            blocks: [],
+            files: [],
+          },
+        });
+        const depAgent = createMockAgent({
+          agentNumber: '001',
+          taskId: '0004-test-plan#001',
+          frontmatter: {
+            status: 'PASS',
+            persona: 'coder',
+            dependencies: [],
+            blocks: [],
+            files: [],
+          },
+        });
+        const allAgents = [agent, depAgent];
+
+        const result = calculateDependencyScore(agent, allAgents, 60);
+
+        expect(result.score).toBe(60);
+      });
+    });
+
+    describe('calculatePriorityScore with custom maxScore', () => {
+      it('uses custom maxScore for agent 0', () => {
+        const agent = createMockAgent({ agentNumber: '000' });
+
+        const result = calculatePriorityScore(agent, 50);
+
+        expect(result.score).toBe(50);
+        expect(result.reasons[0]).toContain('/50');
+      });
+
+      it('decrements proportionally with custom maxScore', () => {
+        const agent = createMockAgent({ agentNumber: '001' });
+
+        const result = calculatePriorityScore(agent, 50);
+
+        // 50 - (1 * 5) = 45 (10% decrement per agent)
+        expect(result.score).toBe(45);
+      });
+    });
+
+    describe('calculateWorkloadScore with custom maxScore', () => {
+      it('uses custom maxScore for no files', () => {
+        const agent = createMockAgent();
+
+        const result = calculateWorkloadScore(agent, 50);
+
+        expect(result.score).toBe(50);
+        expect(result.reasons[0]).toContain('/50');
+      });
+
+      it('decrements proportionally with custom maxScore', () => {
+        const agent = createMockAgent({
+          frontmatter: {
+            status: 'GAP',
+            persona: 'coder',
+            dependencies: [],
+            blocks: [],
+            files: ['src/a.ts'],
+          },
+        });
+
+        const result = calculateWorkloadScore(agent, 60);
+
+        // 60 - (1 * 10) = 50 (1/6 of max per file)
+        expect(result.score).toBe(50);
+      });
+    });
+
+    describe('nextTask with custom weights', () => {
+      it('displays custom weight totals in output', async () => {
+        const customConfig: ServerConfig = {
+          ...config,
+          scoring: {
+            weights: {
+              dependency: 50,
+              priority: 25,
+              workload: 25,
+            },
+          },
+        };
+
+        const planDir = join(plansDir, '0005-custom-weights');
+        const agentsDir = join(planDir, 'agents');
+        mkdirSync(agentsDir, { recursive: true });
+
+        writeFileSync(
+          join(agentsDir, '000_agent.agent.md'),
+          `---
+status: GAP
+persona: coder
+dependencies: []
+blocks: []
+files: []
+---
+
+# Agent 0: Custom Weights Test
+`,
+          'utf-8'
+        );
+
+        const output = await nextTask(customConfig, '5');
+
+        expect(output).toContain('/100'); // total max (50+25+25)
+        expect(output).toContain('/50'); // dependency max
+        expect(output).toContain('/25'); // priority or workload max
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `ScoringWeights` interface with configurable `dependency`, `priority`, and `workload` weights
- Default weights remain 40/30/30 for backward compatibility
- Users can override weights via `config.json` under `scoring.weights`
- CLI output now shows actual configured weight maxes in score breakdowns

## Test plan
- [x] Unit tests for `getScoringWeights()` with defaults, custom, and partial overrides
- [x] Tests for parameterized `calculateDependencyScore`, `calculatePriorityScore`, `calculateWorkloadScore`
- [x] Integration test for `nextTask` displaying custom weight totals
- [x] All 854 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)