### PR TITLE
fix: preserve scoring config when loading and display in config show

### DIFF
--- a/src/cli/config-cmd.ts
+++ b/src/cli/config-cmd.ts
@@ -157,6 +157,21 @@ export function configShow(resolveConfigPathFn: () => string): string {
     lines.push(`  fileExtensions:     ${config.fileExtensions.join(', ')}`);
   }
 
+  if (config.scoring?.weights) {
+    lines.push(`  scoring:`);
+    lines.push(`    weights:`);
+    const weights = config.scoring.weights;
+    if (weights.dependency !== undefined) {
+      lines.push(`      dependency:     ${weights.dependency}`);
+    }
+    if (weights.priority !== undefined) {
+      lines.push(`      priority:       ${weights.priority}`);
+    }
+    if (weights.workload !== undefined) {
+      lines.push(`      workload:       ${weights.workload}`);
+    }
+  }
+
   return lines.join('\n');
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,6 +125,7 @@ export function loadConfig(configPath: string): ServerConfig {
     docsPaths: resolvedDocsPaths,
     fileExtensions: config.fileExtensions,
     dataPath: resolvePath(config.dataPath || DEFAULT_CONFIG.dataPath),
+    scoring: config.scoring,
   };
 
   return mergedConfig;

--- a/tests/cli/config-cmd.test.ts
+++ b/tests/cli/config-cmd.test.ts
@@ -152,6 +152,55 @@ describe('config-cmd', () => {
       expect(output).toContain('Config file not found');
       expect(output).toContain('limps init');
     });
+
+    it('shows scoring config when present', () => {
+      const configPath = join(configDir, 'scoring-config.json');
+      const config = {
+        plansPath: join(testDir, 'plans'),
+        dataPath: join(testDir, 'data'),
+        scoring: {
+          weights: {
+            dependency: 50,
+            priority: 25,
+            workload: 25,
+          },
+        },
+      };
+      writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+      const output = configShow(() => configPath);
+
+      expect(output).toContain('scoring:');
+      expect(output).toContain('weights:');
+      expect(output).toContain('dependency:');
+      expect(output).toContain('50');
+      expect(output).toContain('priority:');
+      expect(output).toContain('25');
+      expect(output).toContain('workload:');
+    });
+
+    it('shows partial scoring weights', () => {
+      const configPath = join(configDir, 'partial-scoring-config.json');
+      const config = {
+        plansPath: join(testDir, 'plans'),
+        dataPath: join(testDir, 'data'),
+        scoring: {
+          weights: {
+            dependency: 60,
+          },
+        },
+      };
+      writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+      const output = configShow(() => configPath);
+
+      expect(output).toContain('scoring:');
+      expect(output).toContain('dependency:');
+      expect(output).toContain('60');
+      // Should not show unset weights
+      expect(output).not.toContain('priority:');
+      expect(output).not.toContain('workload:');
+    });
   });
 
   describe('configPath', () => {


### PR DESCRIPTION
## Summary
- Fix `loadConfig()` to preserve the `scoring` field when loading config from file
- Add scoring weights display to `configShow()` output
- Add tests for scoring config display

## Test plan
- [x] All 856 tests pass
- [x] `npm run validate` passes
- [x] `limps next-task 0030` works with defaults
- [x] `limps config show` displays scoring config when present

🤖 Generated with [Claude Code](https://claude.ai/code)