### PR TITLE
feat(limps): support directory path in config add command

### DIFF
--- a/src/commands/config/add.tsx
+++ b/src/commands/config/add.tsx
@@ -2,11 +2,11 @@ import { Text } from 'ink';
 import { z } from 'zod';
 import { configAdd } from '../../cli/config-cmd.js';
 
-export const description = 'Register an existing config file';
+export const description = 'Register a config file or directory';
 
 export const args = z.tuple([
   z.string().describe('Project name'),
-  z.string().describe('Path to config file'),
+  z.string().describe('Path to config file or directory'),
 ]);
 
 interface Props {


### PR DESCRIPTION
## Summary

- Allow `limps config add <name> <directory>` to accept a directory path
- If the directory contains `config.json`, use it directly
- Otherwise, create config in OS standard location (`~/Library/Application Support/<name>/` on macOS)
- Auto-detect `<dir>/plans` subdirectory for plans path
- Config and data stored separately from the user's repo

This makes it easy to track an existing planning docs directory:
```bash
limps config add my-project .
```

## Test plan

- [x] Unit tests added for directory-based config creation
- [x] Unit tests for using existing config.json in directory
- [x] Unit tests for fallback when no plans subdirectory exists
- [x] All 893 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)