### PR TITLE
docs(plans): archive plan 0044 as completed

### DIFF
--- a/plans/Completed/0044-mcp-server-chart-learnings/0044-mcp-server-chart-learnings-plan.md
+++ b/plans/Completed/0044-mcp-server-chart-learnings/0044-mcp-server-chart-learnings-plan.md
@@ -1,0 +1,156 @@
+# Plan 0044: MCP Server Chart Learnings
+
+## Summary
+Apply learnings from https://github.com/antvis/mcp-server-chart to improve limps documentation, configurability, and skills packaging. Focus is on user-facing clarity (README structure, CLI/ENV docs), optional tool filtering, and a published planning skill for AI IDEs. No transport or Docker implementation in this plan—only documentation and scaffolding.
+
+## Work Type
+features
+
+## Goals
+- Make limps README as discoverable as mcp-server-chart (TOC, features list, CLI options, env vars table).
+- Add optional tool filtering (allow/deny list) to reduce MCP surface area.
+- Package and document a “limps planning skill” for AI IDEs.
+- Document transport options/roadmap for SSE/HTTP as a future-facing section.
+
+## Non‑Goals
+- Implement SSE/HTTP transport.
+- Add Docker packaging.
+- Change core tool behavior beyond filtering.
+
+## References
+- https://github.com/antvis/mcp-server-chart (README structure, tool filtering, skill packaging, multi-transport docs)
+- limps README and CLI tooling
+
+## Feature List
+
+### #1 README & Docs Parity
+**TL;DR**: Add a table of contents, feature highlights, CLI options, and environment variable table. Include Windows config snippets and a “skills” section with install instructions.
+
+**User value**: Faster onboarding, fewer setup mistakes, clearer feature discovery.
+
+#### Gherkin
+- **Scenario:** New user finds setup instructions quickly
+  - Given I open the README
+  - When I scan the table of contents
+  - Then I can jump to Setup, CLI, Config, and MCP Tools
+
+- **Scenario:** User sees available tools and limits
+  - Given the Features section is present
+  - When I read the tool list
+  - Then I understand the capabilities and boundaries
+
+- **Scenario:** Windows user configures MCP correctly
+  - Given I’m on Windows
+  - When I read the setup snippets
+  - Then I can copy a Windows-specific `cmd /c` config
+
+#### TDD Cycle (Docs)
+1. `README includes table of contents` → update README → verify section anchors
+2. `README includes env var table` → add env vars → verify values
+3. `README includes windows setup` → add snippets → verify parity with mac
+
+#### Files
+- `README.md`
+- `packages/limps-headless/README.md` (if mirroring sections)
+- `.claude/commands` (if cross-linking skills)
+
+---
+
+### #2 Tool Filtering (Allow/Deny List)
+**TL;DR**: Add config/env-based tool filtering to limit what tools the MCP server exposes.
+
+**User value**: Reduce tool surface area (security & compatibility), mirror `DISABLED_TOOLS` concept.
+
+#### Gherkin
+- **Scenario:** Disable a tool by name
+  - Given I set `LIMPS_DISABLED_TOOLS="process_doc,process_docs"`
+  - When the server starts
+  - Then those tools are not registered
+
+- **Scenario:** Allowlist only tools
+  - Given I set `LIMPS_ALLOWED_TOOLS="list_docs,search_docs"`
+  - When the server starts
+  - Then only those tools are registered
+
+- **Scenario:** Unknown tool names are ignored
+  - Given the allow/deny list contains unknown tools
+  - When the server starts
+  - Then it logs a warning but does not crash
+
+#### TDD Cycle
+1. `filters tools via allowlist` → implement filter → add tests
+2. `filters tools via denylist` → implement filter → add tests
+3. `unknown tools warned and ignored` → log + test
+
+#### Files
+- `packages/limps/src/tools/index.ts`
+- `packages/limps/src/config.ts`
+- `packages/limps/src/types.ts` (config typing)
+- `packages/limps/tests` (new test coverage)
+- `README.md` (doc)
+
+---
+
+### #3 Publish limps planning skill
+**TL;DR**: Provide a packaged skill that teaches IDEs how to choose limps tools and flows.
+
+**User value**: More consistent tool usage across Cursor/Claude/Codex.
+
+#### Gherkin
+- **Scenario:** User installs skill via npx
+  - Given I run `npx skills add <limps-skill-repo>`
+  - When the installation completes
+  - Then I can invoke a “limps planning” skill from the IDE
+
+- **Scenario:** Skill guides tool selection
+  - Given I ask for “next task”
+  - When the skill runs
+  - Then it chooses `get_next_task` with correct inputs
+
+#### TDD Cycle
+1. `skill repo structure is valid` → create package → validate metadata
+2. `skill docs referenced in README` → add docs → verify link
+
+#### Files
+- `skills/limps-planning` (or new package dir)
+- `README.md` (skill install section)
+- `.claude/skills` (if reusing internal skill content)
+
+---
+
+### #4 Transport & Deployment Docs (Roadmap)
+**TL;DR**: Document current stdio transport and outline future SSE/HTTP support.
+
+**User value**: Sets expectations for remote clients (ChatGPT, hosted use).
+
+#### Gherkin
+- **Scenario:** ChatGPT user understands limits
+  - Given I read the transport section
+  - When I configure ChatGPT
+  - Then I understand current requirement for a proxy
+
+#### TDD Cycle (Docs)
+1. `transport section explains stdio` → add doc → verify clarity
+2. `future transports documented` → add roadmap → verify disclaimers
+
+#### Files
+- `README.md`
+
+## Architecture / Design Notes
+- Tool filtering should be applied in `tools/index.ts` right before registration.
+- Env var precedence: explicit config > env var defaults.
+- Keep lists case-sensitive to tool names (match registry keys).
+- Skills packaging should be externalizable without requiring monorepo tooling.
+
+## Testing Strategy
+- Unit tests for tool filtering (allowlist/denylist + unknown tool names).
+- Documentation checks: verify README sections and links.
+
+## Risks / Gotchas
+- Tool names mismatch between docs and registry keys.
+- Over-filtering could hide required tools for CLI flows.
+
+## Milestones
+- M1: Docs improvements (#1, #4)
+- M2: Tool filtering (#2)
+- M3: Skill packaging (#3)

--- a/plans/Completed/0044-mcp-server-chart-learnings/README.md
+++ b/plans/Completed/0044-mcp-server-chart-learnings/README.md
@@ -1,0 +1,41 @@
+# Plan 0044: MCP Server Chart Learnings
+
+## Overview
+
+Improve limps docs and UX inspired by mcp-server-chart, add optional tool filtering, and publish a limps planning skill package.
+
+## Dependency Graph
+
+```mermaid
+graph TD
+  A[Agent 000: Docs & README] --> B[Agent 001: Tool Filtering]
+  A --> C[Agent 002: Skill Packaging]
+```
+
+## Status Matrix
+
+| Feature | Description | Status | Agent |
+| --- | --- | --- | --- |
+| #1 | README & docs parity | PASS | 000 |
+| #2 | Tool filtering (allow/deny) | PASS | 001 |
+| #3 | Publish limps planning skill | PASS | 002 |
+| #4 | Transport roadmap docs | PASS | 000 |
+
+## Agent Assignments
+
+- **Agent 000: Docs & README**
+  - Owns: #1, #4
+  - Files: `README.md`, `packages/limps-headless/README.md`
+
+- **Agent 001: Tool Filtering**
+  - Owns: #2
+  - Files: `packages/limps/src/tools/index.ts`, `packages/limps/src/config.ts`, `packages/limps/src/types.ts`, tests
+
+- **Agent 002: Skill Packaging**
+  - Owns: #3
+  - Files: `skills/limps-planning/*`, README updates
+
+## Notes
+
+- Keep tool names aligned with actual tool IDs in `packages/limps/src/tools/index.ts`.
+- Ensure docs changes are consistent across limps and limps-headless if applicable.

--- a/plans/Completed/0044-mcp-server-chart-learnings/agents/000_agent_docs.agent.md
+++ b/plans/Completed/0044-mcp-server-chart-learnings/agents/000_agent_docs.agent.md
@@ -1,0 +1,68 @@
+# Agent 0: Docs & README Parity
+
+**Plan Location**: `plans/0044-mcp-server-chart-learnings/0044-mcp-server-chart-learnings-plan.md`
+
+## Scope
+
+Features: #1, #4
+Own: `README.md`, `packages/limps-headless/README.md`
+Depend on: none
+Block: Agent 001/002 can proceed in parallel
+
+## Interfaces
+
+### Export
+
+- Updated README sections: TOC, Features, CLI Options, Environment Variables, Skills, Transport
+- Windows setup snippets
+
+### Receive
+
+- Tool filtering env var names from Agent 001
+- Skill install command/repo from Agent 002
+
+## Features
+
+### #1: README & Docs Parity
+
+TL;DR: Add TOC, features list, CLI options, env var table, Windows config snippets, and skills section.
+Status: `PASS`
+Test IDs: `readme-toc`, `readme-env-table`, `readme-windows-setup`
+Files: `README.md` (edit), `packages/limps-headless/README.md` (edit if needed)
+
+TDD:
+
+1. `README includes TOC` → add TOC → verify anchors
+2. `README includes env var table` → add table → verify values
+3. `README includes windows setup` → add snippet → verify parity
+
+Gotchas:
+
+- Keep section names stable to avoid breaking existing links
+
+---
+
+### #4: Transport & Deployment Docs
+
+TL;DR: Document current stdio transport and future SSE/HTTP roadmap.
+Status: `PASS`
+Test IDs: `readme-transport-section`
+Files: `README.md` (edit)
+
+TDD:
+
+1. `transport section exists` → add section → verify clarity
+2. `roadmap disclaimers included` → add notes → verify no promises
+
+Gotchas:
+
+- Avoid implying SSE/HTTP is already supported
+
+---
+
+## Done
+
+- [x] README sections updated and consistent
+- [x] Windows config snippet validated
+- [x] Transport roadmap section added
+- [x] Status → PASS

--- a/plans/Completed/0044-mcp-server-chart-learnings/agents/001_agent_tool_filtering.agent.md
+++ b/plans/Completed/0044-mcp-server-chart-learnings/agents/001_agent_tool_filtering.agent.md
@@ -1,0 +1,63 @@
+# Agent 1: Tool Filtering (Allow/Deny)
+
+**Plan Location**: `plans/0044-mcp-server-chart-learnings/0044-mcp-server-chart-learnings-plan.md`
+
+## Scope
+
+Features: #2
+Own: `packages/limps/src/tools/index.ts`, `packages/limps/src/config.ts`, `packages/limps/src/types.ts`, tests
+Depend on: none
+Block: Agent 000 for env var names (sync doc wording)
+
+## Interfaces
+
+### Export
+
+```ts
+export interface ToolFilteringConfig {
+  allowlist?: string[];
+  denylist?: string[];
+}
+```
+
+```ts
+export function filterToolDefinitions(
+  tools: ToolDefinition[],
+  config: ToolFilteringConfig | undefined,
+  env: NodeJS.ProcessEnv
+): ToolDefinition[];
+```
+
+### Receive
+
+- None
+
+## Features
+
+### #2: Tool Filtering
+
+TL;DR: Allow/deny list controls which MCP tools are registered.
+Status: `PASS`
+Test IDs: `tool-filter-allowlist`, `tool-filter-denylist`, `tool-filter-unknown`
+Files: `packages/limps/src/tools/index.ts` (edit), `packages/limps/src/config.ts` (edit), `packages/limps/src/types.ts` (edit), tests
+
+TDD:
+
+1. `filters tools via allowlist` → implement filter → refactor names
+2. `filters tools via denylist` → implement filter → refactor
+3. `unknown tools warned` → log + test
+
+Gotchas:
+
+- Tool names must match registry keys exactly
+- Avoid filtering required internal tools (if any)
+
+---
+
+## Done
+
+- [x] Allowlist and denylist supported
+- [x] Unknown tools warned and ignored
+- [x] Config + env var precedence documented
+- [x] Tests added
+- [x] Status → PASS

--- a/plans/Completed/0044-mcp-server-chart-learnings/agents/002_agent_skills_packaging.agent.md
+++ b/plans/Completed/0044-mcp-server-chart-learnings/agents/002_agent_skills_packaging.agent.md
@@ -1,0 +1,48 @@
+# Agent 2: Skills Packaging
+
+**Plan Location**: `plans/0044-mcp-server-chart-learnings/0044-mcp-server-chart-learnings-plan.md`
+
+## Scope
+
+Features: #3
+Own: `skills/limps-planning/*`, README skills section
+Depend on: Agent 000 for README placement
+Block: none
+
+## Interfaces
+
+### Export
+
+- Published skill package structure with README and usage
+- Install command documented in limps README
+
+### Receive
+
+- None
+
+## Features
+
+### #3: Publish limps planning skill
+
+TL;DR: Provide a standalone skill package with prompts and tool-selection guidance.
+Status: `PASS`
+Test IDs: `skills-structure-valid`, `readme-skills-section`
+Files: `skills/limps-planning/*` (create), `README.md` (edit)
+
+TDD:
+
+1. `skill repo structure is valid` → create package → validate metadata
+2. `skill docs referenced in README` → add docs → verify link
+
+Gotchas:
+
+- Ensure skill package is consumable via `npx skills add ...`
+- Keep tool names aligned with limps MCP tool IDs
+
+---
+
+## Done
+
+- [x] Skill package created
+- [x] README contains install + usage snippet
+- [x] Status → PASS

--- a/plans/Completed/0044-mcp-server-chart-learnings/gotchas.md
+++ b/plans/Completed/0044-mcp-server-chart-learnings/gotchas.md
@@ -1,0 +1,4 @@
+# Gotchas
+
+## Initial
+- None yet. Capture surprises here as they appear during implementation.

--- a/plans/Completed/0044-mcp-server-chart-learnings/interfaces.md
+++ b/plans/Completed/0044-mcp-server-chart-learnings/interfaces.md
@@ -1,0 +1,52 @@
+# Interfaces
+
+## Config Additions
+
+```ts
+export interface ToolFilteringConfig {
+  allowlist?: string[]; // Explicit tools to expose
+  denylist?: string[];  // Tools to hide
+}
+
+export interface ServerConfig {
+  // existing fields...
+  tools?: ToolFilteringConfig;
+}
+```
+
+### Env Vars
+
+```ts
+// Comma-separated tool names
+process.env.LIMPS_ALLOWED_TOOLS
+process.env.LIMPS_DISABLED_TOOLS
+```
+
+### Precedence
+1. `config.tools.allowlist` / `config.tools.denylist`
+2. `LIMPS_ALLOWED_TOOLS` / `LIMPS_DISABLED_TOOLS`
+3. default: no filtering
+
+## Tool Registration Filter
+
+```ts
+export function filterToolDefinitions(
+  tools: ToolDefinition[],
+  config: ToolFilteringConfig | undefined,
+  env: NodeJS.ProcessEnv
+): ToolDefinition[];
+```
+
+### Expected Behavior
+- If allowlist present: only those tool names are registered.
+- Else if denylist present: all except those are registered.
+- Unknown tool names are ignored with a warning.
+- Filtering must not change tool schemas or IDs.
+
+## README Sections
+
+- **Features**: list of available tools + short descriptions
+- **CLI Options**: top-level options + key subcommands
+- **Environment Variables**: table including `LIMPS_PROJECT`, `LIMPS_ALLOWED_TOOLS`, `LIMPS_DISABLED_TOOLS`
+- **Skills**: install + usage of limps planning skill
+- **Transport**: stdio + roadmap for SSE/HTTP


### PR DESCRIPTION
## Summary
- move plan 0044 artifacts into the Completed plans folder

## Changes
- add completed plan files under `plans/Completed/0044-mcp-server-chart-learnings/`

## Tests
- not run (docs-only change)

## Notes / Risks
- none