### PR TITLE
feat(ci): add MCP Registry publish via mcp-publisher OIDC

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,6 +68,39 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-mcp-registry:
+    needs: [release-please, publish-limps]
+    if: ${{ needs.release-please.outputs['limps--release_created'] }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve version from package.json
+        id: version
+        run: |
+          VERSION=$(node -e "console.log(require('./packages/limps/package.json').version)")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Patch server.json version
+        run: |
+          jq --arg v "${{ steps.version.outputs.VERSION }}" \
+            '.version = $v | .packages[0].version = $v' \
+            server.json > server.tmp && mv server.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+
   publish-limps-headless:
     needs: release-please
     if: ${{ needs.release-please.outputs['limps-headless--release_created'] }}

--- a/packages/limps/package.json
+++ b/packages/limps/package.json
@@ -2,6 +2,7 @@
   "name": "@sudosandwich/limps",
   "version": "2.11.0",
   "description": "Local Intelligent MCP Planning Server - AI agent plan management",
+  "mcpName": "io.github.paulbreuler/limps",
   "type": "module",
   "main": "dist/index.js",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.paulbreuler/limps",
+  "description": "Local Intelligent MCP Planning Server — AI agent plan management with full-text search, task lifecycle, and document processing",
+  "repository": {
+    "url": "https://github.com/paulbreuler/limps",
+    "source": "github"
+  },
+  "version": "2.11.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@sudosandwich/limps",
+      "version": "2.11.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds automatic publishing to the official MCP Registry (`registry.modelcontextprotocol.io`) on every limps npm release
- LobeHub, GitHub's registry view, and other indexers scrape from this registry — this closes the gap

## Changes
- **`server.json`** (new) — MCP Registry manifest. Version fields are set to current (`2.11.0`) in the file but are overwritten at CI time from `packages/limps/package.json`, so release-please remains the single version source of truth with zero extra maintenance.
- **`packages/limps/package.json`** — Added `mcpName` field (`io.github.paulbreuler/limps`). The registry pulls the published npm tarball and validates this matches `server.json .name`; without it the publish fails.
- **`.github/workflows/release-please.yml`** — New `publish-mcp-registry` job:
  - Chains after `publish-limps` (registry validates the npm package exists first)
  - Job-scoped `id-token: write` only (does not affect sibling jobs)
  - Reads version from `package.json`, patches both version fields in `server.json` via `jq`
  - Authenticates via GitHub OIDC (no new secrets required)
  - Downloads and runs `mcp-publisher` from the official `modelcontextprotocol/registry` releases

## Tests
- Pre-commit hooks passed (format, lint, type-check, build)
- `jq` version-patch validated locally against `server.json` (dry-run with a future version confirmed both fields update correctly)
- `node -e "require(...).version"` confirmed to resolve correctly from the repo root (CJS context, works despite the package being ESM)

## Code Review
- General review: ✅ Passed — dependency graph, version patching, permission scoping, and identifier consistency all verified correct
- MCP/LLM review: ✅ Passed — OIDC token correctly job-scoped, no leak paths; `server.json` description is prompt-injection-safe; `jq --arg` neutralises jq-level injection on the version string
- Commit review: ✅ Single conventional-commit, atomic

## Residual Risks (acknowledged, not blockers)
- **`mcp-publisher` pinned to `latest`, not a tagged release.** No checksum verification on the downloaded binary. This matches the pattern used by the majority of CLI tools distributed via GitHub releases. Worth filing upstream to ask if checksums are published, and pinning to a specific tag in a follow-up once stable.
- **`server.json` is PR-modifiable.** A future hardening step could add a CI assertion that `packages[0].identifier` matches `packages/limps/package.json .name`. Low priority given the OIDC publish only runs on `main` after release-please merges.
- **Remote vs manifest identity:** The git remote is `base-state/limps` while `package.json` (pre-existing) and `server.json` both declare `paulbreuler/limps`. The OIDC token's `sub` claim will reflect whichever GitHub account owns the Actions runner. Confirm the `paulbreuler` namespace is the correct publish identity before merging.

## Notes / Risks
- No new secrets required — OIDC auth is the only mechanism used
- No application code changed; this is CI + config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)