### PR TITLE
fix(ci): pin mcp-publisher to v1.4.0 and verify SHA-256 checksum

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,8 +92,19 @@ jobs:
             server.json > server.tmp && mv server.tmp server.json
 
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.4.0
         run: |
-          curl -sSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          TARBALL="mcp-publisher_${OS}_${ARCH}.tar.gz"
+          BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+          CHECKSUMS_FILE="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+          curl -sSLo "${TARBALL}" "${BASE_URL}/${TARBALL}"
+          curl -sSLo "${CHECKSUMS_FILE}" "${BASE_URL}/${CHECKSUMS_FILE}"
+          grep "  ${TARBALL}$" "${CHECKSUMS_FILE}" | sha256sum -c -
+          tar xzf "${TARBALL}" mcp-publisher
 
       - name: Authenticate via GitHub OIDC
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
## Summary
Closes the supply-chain gap identified in #76: `mcp-publisher` was fetched from
`/releases/latest` with no integrity check and piped straight into `tar`.  The
binary is the first thing executed after download, and it runs with the OIDC
token in scope, so a tampered binary has a direct path to the publish credential.

## What changed
Single step rewrite in the `publish-mcp-registry` job
(`release-please.yml:94-107`).  Nothing else touched.

| Before | After |
|---|---|
| `curl … /releases/latest/… \| tar xz` | Pin to `v1.4.0` via `MCP_PUBLISHER_VERSION` env var |
| No integrity check | Downloads `registry_1.4.0_checksums.txt` (shipped by upstream on every release) |
| Non-deterministic (`latest` can move) | `grep` + `sha256sum -c` verifies before `tar` extracts |
| | `set -euo pipefail` — any failure aborts the job |

## Upgrade path
When a new `mcp-publisher` release ships, bump the single env var:
```yaml
env:
  MCP_PUBLISHER_VERSION: v1.4.0   # ← change this
```
The checksums file name is derived from it automatically (`registry_<ver>_checksums.txt`),
so no other lines need editing.

## Verification
- Dry-run executed locally against real `v1.4.0` assets (`darwin/arm64`):
  tarball downloaded, checksum matched (`OK`), binary extracted successfully.
- `grep` pattern anchored with trailing `$` to prevent partial filename collisions.
- `sha256sum -c -` reads from stdin; single-line input is the standard usage.

## What this does NOT do
- Does not add sigstore verification (the `.sigstore.json` bundles shipped
  alongside each tarball).  SHA-256 against the upstream checksums file is the
  standard first layer; sigstore can follow in a subsequent hardening pass if
  desired.

## Notes / Risks
- None introduced.  This is a strict reduction of attack surface over the
  previous state.
- The checksums file itself is fetched over HTTPS from `github.com` (same
  trust boundary as the tarball).  Sigstore bundles would independently attest
  the build provenance if that boundary is ever a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)