### PR TITLE
fix(ci): shorten server.json description to meet registry 100-char limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.paulbreuler/limps",
-  "description": "Local Intelligent MCP Planning Server — AI agent plan management with full-text search, task lifecycle, and document processing",
+  "description": "MCP planning server for AI agents — plan management, full-text search, and task lifecycle",
   "repository": {
     "url": "https://github.com/paulbreuler/limps",
     "source": "github"
   },
-  "version": "2.11.0",
+  "version": "2.12.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sudosandwich/limps",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
`mcp-publisher publish` is returning 422 on every run because
`server.json` `description` is 127 characters; the registry enforces a
hard 100-character limit.  This also syncs the version fields to
`2.12.0` so the committed file matches what release-please already
bumped in `package.json`.

## Changes (`server.json` only)
| Field | Before | After |
|---|---|---|
| `description` | 127 chars — "Local Intelligent MCP Planning Server — AI agent plan management with full-text search, task lifecycle, and document processing" | 89 chars — "MCP planning server for AI agents — plan management, full-text search, and task lifecycle" |
| `version` | 2.11.0 | 2.12.0 (matches `package.json`; CI overwrites this at publish time anyway) |
| `packages[0].version` | 2.11.0 | 2.12.0 (same) |

## Verification
- `node -e` confirms new description is 89 characters (limit 100)
- Both version fields match `packages/limps/package.json`
- No other files touched

## Notes
- The version fields in `server.json` are patched from `package.json`
  at CI time by the `publish-mcp-registry` job, so the committed values
  are cosmetic.  Keeping them in sync with the actual published version
  avoids confusion when reading the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)