### PR TITLE
feat(ci): let release-please bump server.json versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -79,18 +79,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Resolve version from package.json
-        id: version
-        run: |
-          VERSION=$(node -e "console.log(require('./packages/limps/package.json').version)")
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Patch server.json version
-        run: |
-          jq --arg v "${{ steps.version.outputs.VERSION }}" \
-            '.version = $v | .packages[0].version = $v' \
-            server.json > server.tmp && mv server.tmp server.json
-
       - name: Install mcp-publisher
         env:
           MCP_PUBLISHER_VERSION: v1.4.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,19 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "component": "limps"
+      "component": "limps",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "/server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "/server.json",
+          "jsonpath": "$.packages[0].version"
+        }
+      ]
     },
     "packages/limps-headless": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
`server.json` version fields were being patched at CI publish-time via a
`jq` one-liner that read from `package.json`.  That works, but it means
release-please is not the single source of truth — the committed
`server.json` is always one version behind until the publish job runs.
This PR moves ownership to release-please so both files are bumped in
the same release PR, just like `package.json`.

## Changes

### `release-please-config.json`
Added `extra-files` to the `packages/limps` entry with two entries
targeting `server.json`:
- `$.version` — the top-level version field
- `$.packages[0].version` — the npm package version inside the manifest

Paths use the `/`-prefixed repo-root-absolute form because release-please
explicitly blocks `../` traversal out of a package directory
([googleapis/release-please#2477](https://github.com/googleapis/release-please/issues/2477)).

### `.github/workflows/release-please.yml`
Removed the two steps that are now redundant:
- **"Resolve version from package.json"** — extracted version into a
  step output
- **"Patch server.json version"** — wrote that version into
  `server.json` via `jq`

The `publish-mcp-registry` job now goes straight from checkout →
install mcp-publisher → authenticate → publish.  The checked-out
`server.json` already has the correct version because release-please
bumped it in the release PR before this job ever runs.

## How it works end-to-end
1. Conventional commit lands on `main`
2. release-please opens its release PR, bumping `packages/limps/package.json`
   **and** both version fields in `server.json`
3. PR merges → release-please creates a GitHub release
4. `publish-limps` publishes to npm
5. `publish-mcp-registry` checks out the already-correct `server.json`
   and publishes to the MCP Registry — no runtime patching needed

## Merge order note
#78 (description length fix) should merge before or alongside this one.
Both target `server.json` but on different fields so there is no
conflict either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)