### PR TITLE
feat(ci): extract MCP Registry publish into reusable + manually triggerable workflow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,42 @@
+name: Publish to MCP Registry
+
+on:
+  # Called automatically by release-please after a successful npm publish
+  workflow_call:
+
+  # Manual trigger — use this to re-publish after a registry outage or
+  # to publish a version that was missed (e.g. the registry job failed
+  # on the original release run).
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.4.0
+        run: |
+          set -euo pipefail
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          TARBALL="mcp-publisher_${OS}_${ARCH}.tar.gz"
+          BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+          CHECKSUMS_FILE="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+          curl -sSLo "${TARBALL}" "${BASE_URL}/${TARBALL}"
+          curl -sSLo "${CHECKSUMS_FILE}" "${BASE_URL}/${CHECKSUMS_FILE}"
+          grep "  ${TARBALL}$" "${CHECKSUMS_FILE}" | sha256sum -c -
+          tar xzf "${TARBALL}" mcp-publisher
+
+      - name: Authenticate via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,34 +71,7 @@ jobs:
   publish-mcp-registry:
     needs: [release-please, publish-limps]
     if: ${{ needs.release-please.outputs['limps--release_created'] }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install mcp-publisher
-        env:
-          MCP_PUBLISHER_VERSION: v1.4.0
-        run: |
-          set -euo pipefail
-          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
-          TARBALL="mcp-publisher_${OS}_${ARCH}.tar.gz"
-          BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
-          CHECKSUMS_FILE="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
-          curl -sSLo "${TARBALL}" "${BASE_URL}/${TARBALL}"
-          curl -sSLo "${CHECKSUMS_FILE}" "${BASE_URL}/${CHECKSUMS_FILE}"
-          grep "  ${TARBALL}$" "${CHECKSUMS_FILE}" | sha256sum -c -
-          tar xzf "${TARBALL}" mcp-publisher
-
-      - name: Authenticate via GitHub OIDC
-        run: ./mcp-publisher login github-oidc
-
-      - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+    uses: ./.github/workflows/publish-mcp-registry.yml
 
   publish-limps-headless:
     needs: release-please


### PR DESCRIPTION
## Summary
The `publish-mcp-registry` job only fires when release-please sets
`limps--release_created`.  Our CI fixes (#77 #78 #79) are all
`(ci)`-scoped and only touch repo-root files — release-please does
path-based commit filtering in monorepo mode and doesn't associate
them with `packages/limps`, so no release PR is opened and the MCP
Registry publish never re-runs.

This PR extracts the publish logic into a standalone reusable workflow
so it can be triggered manually right now to publish `2.12.0` with the
fixed `server.json`, and acts as a proper fallback for any future
registry outage.

## Changes

### New: `.github/workflows/publish-mcp-registry.yml`
- Triggers on `workflow_call` (called by release-please on release) **and**
  `workflow_dispatch` (manual trigger from the Actions UI or API)
- Contains the exact same steps that were inline: pinned `mcp-publisher`
  `v1.4.0`, SHA-256 checksum verification, OIDC auth, publish
- Zero duplication — this IS the single source of truth for the publish logic

### Modified: `.github/workflows/release-please.yml`
- The `publish-mcp-registry` job is now 3 lines:
  ```yaml
  publish-mcp-registry:
    needs: [release-please, publish-limps]
    if: ${{ needs.release-please.outputs['limps--release_created'] }}
    uses: ./.github/workflows/publish-mcp-registry.yml
  ```
- Automatic-on-release behaviour is identical to before

## How to trigger manually once merged
```bash
gh workflow run publish-mcp-registry.yml --repo paulbreuler/limps
```
Or via the Actions UI → "Publish to MCP Registry" → Run workflow.

## Why not just cut 2.13.0?
`2.12.0` is already on npm with `mcpName` and the correct package code.
The only thing that failed was the registry metadata publish (422 on
description length, now fixed on main).  Publishing `2.12.0` metadata
to the registry is the correct action — a new npm release would be
an empty bump with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)