### PR TITLE
fix(ci): add workflow_dispatch trigger to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to the Release Please workflow to allow manual triggering when the automatic push trigger doesn't fire.

## Context

PR #114 was merged successfully, but the Release Please workflow didn't trigger automatically. This is likely due to timing issues or GitHub service disruptions.

## Changes

- Added `workflow_dispatch:` trigger to `.github/workflows/release-please.yml`
- Allows manual triggering via: `gh workflow run release-please.yml --ref main`

## Testing

- All 1,293 tests passing
- Workflow file validated

## Benefits

- Provides backup mechanism for release creation
- Useful for debugging workflow issues
- No breaking changes - existing push trigger still works

---

Related to #114