### PR TITLE
fix(limps): clarify daemon wording in default command help

### DIFF
--- a/packages/limps/src/commands/index.tsx
+++ b/packages/limps/src/commands/index.tsx
@@ -28,9 +28,9 @@ export default function DefaultCommand(): React.ReactNode {
       {'\n'}
       <Text color="cyan">HTTP Server:</Text>
       {'\n'}
-      {'  '}start{'          '}Start the HTTP MCP server{'\n'}
-      {'  '}stop{'           '}Stop the HTTP server{'\n'}
-      {'  '}server-status{'  '}Show server status{'\n'}
+      {'  '}start{'          '}Start the HTTP daemon{'\n'}
+      {'  '}stop{'           '}Stop the HTTP daemon{'\n'}
+      {'  '}server-status{'  '}Show daemon status{'\n'}
       {'\n'}
       <Text color="cyan">Plan Management:</Text>
       {'\n'}


### PR DESCRIPTION
## Summary
- align default command help text with daemon terminology
- update start, stop, and server-status descriptions in packages/limps/src/commands/index.tsx

## Why
- main currently has a non-conventional merge commit (8853d63), so release-please did not create a release PR
- merging this conventional fix(limps) PR into main should trigger release-please and start the missed patch release flow

## Validation
- pre-push hooks passed (format/lint/type-check/build + tests in both workspaces)