### PR TITLE
ci(test): add macOS to the CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    
+    runs-on: ${{ matrix.os }}
+
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         node-version: [20.x, 22.x]
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- run the existing CI test workflow on both `ubuntu-latest` and `macos-latest`
- keep Node.js coverage at `20.x` and `22.x`
- set `fail-fast: false` so one matrix failure does not cancel the rest

## Why
- we hit a macOS-specific issue that Linux CI did not catch
- this adds cross-platform coverage while keeping current Node version coverage

## Validation
- local pre-push hooks passed (lint, type-check, build, and full workspace test suites)