### PR TITLE
fix(cli): support status --set for non-canonical plansPath

### DIFF
--- a/packages/limps/src/agent-parser.ts
+++ b/packages/limps/src/agent-parser.ts
@@ -117,16 +117,20 @@ export function extractAgentNumber(filename: string): string | null {
  * Extract plan folder from agent file path.
  *
  * @example
- * extractPlanFolder("/path/to/plans/0022-datagrid-stories/agents/000_agent.agent.md")
+ * extractPlanFolder("/path/to/0022-datagrid-stories/agents/000_agent.agent.md")
  * // "0022-datagrid-stories"
  *
  * @param path - Full path to agent file
  * @returns Plan folder name or null if not found
  */
 export function extractPlanFolder(path: string): string | null {
-  // Match plans/<folder>/agents/
-  const match = path.match(/plans[/\\]([^/\\]+)[/\\]agents[/\\]/);
-  return match ? match[1] : null;
+  // Plan folder is the path segment directly before "agents"
+  const segments = path.split(/[/\\]+/).filter(Boolean);
+  const agentsIndex = segments.lastIndexOf('agents');
+  if (agentsIndex <= 0) {
+    return null;
+  }
+  return segments[agentsIndex - 1] || null;
 }
 
 /**

--- a/packages/limps/tests/agent-parser.test.ts
+++ b/packages/limps/tests/agent-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseAgentFile } from '../src/agent-parser.js';
+import { parseAgentFile, extractPlanFolder } from '../src/agent-parser.js';
 
 describe('agent-parser', () => {
   it('normalizes depends_on values into dependencies', () => {
@@ -40,5 +40,35 @@ files: []
       return;
     }
     expect(parsed.frontmatter.dependencies).toEqual([]);
+  });
+
+  it('extracts plan folder without requiring a /plans/ path segment', () => {
+    const planFolder = extractPlanFolder(
+      '/workspace/my-project/0007-feature/agents/002_test.agent.md'
+    );
+    expect(planFolder).toBe('0007-feature');
+  });
+
+  it('parses agent files in non-canonical plansPath layouts', () => {
+    const content = `---
+status: GAP
+persona: coder
+dependencies: []
+blocks: []
+files: []
+---
+
+# Agent 2
+`;
+    const parsed = parseAgentFile(
+      '/workspace/repo-root/0007-feature/agents/002_test.agent.md',
+      content
+    );
+    expect(parsed).not.toBeNull();
+    if (!parsed) {
+      return;
+    }
+    expect(parsed.planFolder).toBe('0007-feature');
+    expect(parsed.taskId).toBe('0007-feature#002');
   });
 });

--- a/packages/limps/tests/cli/status-update.test.ts
+++ b/packages/limps/tests/cli/status-update.test.ts
@@ -37,6 +37,43 @@ describe('updateAgentStatus', () => {
   });
 
   describe('status transitions', () => {
+    it('should update status when agent file path does not include /plans/ segment', () => {
+      const planDir = join(testDir, '0001-test-plan');
+      const agentsDir = join(planDir, 'agents');
+      mkdirSync(agentsDir, { recursive: true });
+
+      const agentPath = join(agentsDir, '000_agent.agent.md');
+      writeFileSync(
+        agentPath,
+        `---
+status: GAP
+persona: coder
+dependencies: []
+blocks: []
+files: []
+---
+
+# Test Agent
+`,
+        'utf-8'
+      );
+
+      const resolvedId: ResolvedTaskId = {
+        taskId: '0001-test-plan#000',
+        planFolder: '0001-test-plan',
+        agentNumber: '000',
+        path: agentPath,
+      };
+
+      const result = updateAgentStatus(config, resolvedId, 'WIP');
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('GAP to WIP');
+
+      const updatedContent = readFileSync(agentPath, 'utf-8');
+      expect(updatedContent).toContain('status: WIP');
+    });
+
     it('should update status from GAP to WIP', () => {
       const planDir = join(plansDir, '0001-test-plan');
       const agentsDir = join(planDir, 'agents');


### PR DESCRIPTION
## Summary
- fix plan folder extraction from agent file paths so it no longer requires a `/plans/` path segment
- make `status --set` work when `plansPath` points to repo root (plan folders directly under root)
- add regression tests for parser and status update paths

## Root Cause
`extractPlanFolder()` only matched paths containing `plans/<plan>/agents/...`, so parsing returned `null` for valid agent files in non-canonical layouts.

## Validation
- `npm --workspace @sudosandwich/limps test -- tests/agent-parser.test.ts tests/cli/status-update.test.ts tests/update-task-status.test.ts`
- `npm test` (workspace pre-push hook ran full monorepo suites)
- manual E2E: `limps status 0001 --agent 000 --set WIP --config <config>` in a temp project with `plansPath` set to repo root
